### PR TITLE
Bump App Engine runtime from nodejs10 to nodejs12

### DIFF
--- a/app.alfajores.yaml
+++ b/app.alfajores.yaml
@@ -1,4 +1,4 @@
-runtime: nodejs10
+runtime: nodejs12
 service: indexer
 instance_class: B4
 manual_scaling:

--- a/app.mainnet.yaml
+++ b/app.mainnet.yaml
@@ -1,4 +1,4 @@
-runtime: nodejs10
+runtime: nodejs12
 service: indexer
 instance_class: B4
 manual_scaling:


### PR DESCRIPTION
nodejs12 matches the engine constraint in package.json.