### PR TITLE
Convert to more module-like structure

### DIFF
--- a/bin/indexer.ts
+++ b/bin/indexer.ts
@@ -1,0 +1,14 @@
+import { PORT } from './config'
+import initApp from './'
+
+async function main() {
+  const app = await initApp()
+  app.listen(PORT, () => {
+    console.info(`App listening on port ${PORT}`)
+  })
+}
+
+main().catch((err) => {
+  console.error(err)
+  process.exit(1)
+})

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@valora/indexer",
   "description": "Store events on the Celo blockchain into a relational database",
   "version": "0.0.5",
-  "private": true,
+  "main": "dist/index.js",
   "author": "Valora Inc",
   "license": "Apache-2.0",
   "scripts": {
@@ -10,9 +10,9 @@
     "gcp-build": "npm run build",
     "test": "cp config/config.test.env .env; DB_TYPE=sqlite jest",
     "test:watch": "yarn test --watch",
-    "lint": "eslint --ext=.tsx,.ts src/ test/",
-    "start": "node ./dist/index.js",
-    "start:local": "yarn build; cp config/config.local.env .env; node --inspect ./dist/index.js",
+    "lint": "eslint --ext=.tsx,.ts src/ test/ bin/",
+    "start": "node ./dist/bin/indexer.js",
+    "start:local": "yarn build; cp config/config.local.env .env; node --inspect ./dist/bin/indexer.js",
     "deploy": "./deploy.sh"
   },
   "dependencies": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,44 +4,46 @@ import { ENVIRONMENT, PORT, VERSION, WEB3_PROVIDER_URL } from './config'
 import { initDatabase } from './database/db'
 import { pollers } from './polling'
 
-console.info('Service starting with environment, version:', ENVIRONMENT, VERSION)
-const START_TIME = Date.now()
+export default async function initApp() : Promise<express.Application> {
+  console.info('Service starting with environment, version:', ENVIRONMENT, VERSION)
+  const START_TIME = Date.now()
 
-/**
- * Create and configure Express server
- * This is a necessary requirement for an app to run stably on App Engine
- */
-console.info('Creating express server')
-const app = express()
-app.set('port', PORT)
-app.set('env', ENVIRONMENT)
-app.use(express.json())
+  /**
+   * Create and configure Express server
+   * This is a necessary requirement for an app to run stably on App Engine
+   */
+  console.info('Creating express server')
+  const app = express()
+  app.set('port', PORT)
+  app.set('env', ENVIRONMENT)
+  app.use(express.json())
 
-// Primary app routes.
-app.get('/', (req: any, res: any) => {
-  res.send('Celo Indexer. See /status for details.')
-})
-app.get('/status', (req: any, res: any) => {
-  res.status(200).json({
-    version: VERSION,
-    serviceStartTime: new Date(START_TIME).toUTCString(),
-    serviceRunDuration: Math.floor((Date.now() - START_TIME) / 60000) + ' minutes',
+  // Primary app routes.
+  app.get('/', (req: any, res: any) => {
+    res.send('Celo Indexer. See /status for details.')
   })
-})
-app.get('/_ah/start', (req: any, res: any) => {
-  res.status(200).end()
-})
+  app.get('/status', (req: any, res: any) => {
+    res.status(200).json({
+      version: VERSION,
+      serviceStartTime: new Date(START_TIME).toUTCString(),
+      serviceRunDuration: Math.floor((Date.now() - START_TIME) / 60000) + ' minutes',
+    })
+  })
+  app.get('/_ah/start', (req: any, res: any) => {
+    res.status(200).end()
+  })
 
-// Start Server
-app.listen(PORT, () => {
-  console.info(`App listening on port ${PORT} with env ${ENVIRONMENT}`)
-})
+  try {
+    await initDatabase()
+    pollers.forEach((poller) => poller.run())
+  } catch (error) {
+    console.error('Error initializing database', error)
+    throw error
+  }
+  if (!WEB3_PROVIDER_URL) {
+    console.info('No Web3 provider found. Skipping exchange polling.')
+    console.info('Note that you will need to manually set contract addresses.')
+  }
 
-initDatabase()
-  .then(() => pollers.forEach((poller) => poller.run()))
-  .catch((error) => console.error('Error initializing database', error))
-
-if (!WEB3_PROVIDER_URL) {
-  console.info('No Web3 provider found. Skipping exchange polling.')
-  console.info('Note that you will need to manually set contract addresses.')
+  return app
 }

--- a/tsconfig.eslint.json
+++ b/tsconfig.eslint.json
@@ -2,6 +2,7 @@
   "extends": "./tsconfig.json",
   "include": [
     "src/**/*",
-    "test/**/*"
+    "test/**/*",
+    "bin/**/*"
   ]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,8 +12,9 @@
     "sourceMap": true,
     "strict": true,
     "target": "es6",
-    "lib": ["es7", "esnext"]
+    "lib": ["es7", "esnext"],
+    "rootDirs": ["src", "bin"]
   },
-  "include": ["src/**/*"],
+  "include": ["src/**/*", "bin/**/*"],
   "exclude": ["node_modules", "vendor", ".bundle"]
 }


### PR DESCRIPTION
This helps users customize the indexer configuration. For example, pulling in
DB credential secrets using whatever organization-specific method.