### PR TITLE
Tweak kubernetes.yaml

### DIFF
--- a/kubernetes.yaml
+++ b/kubernetes.yaml
@@ -16,7 +16,7 @@ spec:
           - ReadWriteOnce
         resources:
           requests:
-            storage: 4Gi
+            storage: 256Gi
   template:
     metadata:
       labels:
@@ -72,7 +72,7 @@ spec:
     spec:
       containers:
         - name: indexer
-          image: gcr.io/valora-inc/indexer:latest
+          image: gcr.io/valora-inc/indexer:a0f47727ce7abd43a1bcc87b48abecb22b8ef5ce
           envFrom:
             - configMapRef:
                 name: indexer


### PR DESCRIPTION
* Bump Kubernetes Persistent Volume Claim in 256 GBytes. 256 GBytes is
   what cLabs recommends for network nodes, so we should at least match
   that for the data drive.
* Use the SHA tagged image.