### PR TITLE
fix: missing events

### DIFF
--- a/src/indexer/index.ts
+++ b/src/indexer/index.ts
@@ -106,7 +106,12 @@ export async function indexEvents(
             })
             .transacting(trx)
         })
-        await setLastBlock(key, toBlock).transacting(trx)
+        if (events.length > 0) {
+          await setLastBlock(
+            key,
+            events[events.length - 1].blockNumber,
+          ).transacting(trx)
+        }
       })
     }
   } catch (error) {

--- a/test/indexer.test.ts
+++ b/test/indexer.test.ts
@@ -73,7 +73,7 @@ describe('Indexer', () => {
     ).toBeTruthy()
 
     const key = `${Contract.Accounts}_${Event.AccountWalletAddressSet}`
-    expect(await getLastBlock(key)).toEqual(toBlock)
+    expect(await getLastBlock(key)).toEqual(1234)
   })
 
   it("halts when there's an error storing events", async () => {


### PR DESCRIPTION
This fix was suggested by @gnardini ([see thread](https://valora-app.slack.com/archives/C029Z1QMD7B/p1655219097079179?thread_ts=1655217070.420859&cid=C029Z1QMD7B)).

It sets the last block to the block number of the last event we've actually seen (instead of the last block number in the queried range).

It's been tested by deploying a new indexer ([indexer3](https://github.com/valora-inc/indexer/tree/jeanregisser/indexer3)).
And the results were [conclusive](https://valora-app.slack.com/archives/C029Z1QMD7B/p1657275585357159?thread_ts=1655217070.420859&cid=C029Z1QMD7B). We even had more transfers than [in blockscout's snapshot](https://valora-app.slack.com/archives/C9RSRC8KS/p1656434959997719?thread_ts=1655283149.810229&cid=C9RSRC8KS). Also also [this thread](https://valora-app.slack.com/archives/C02DY3RK79T/p1656435223689119?thread_ts=1656421334.301979&cid=C02DY3RK79T).

From these tests, it seems to indicate querying past events up to the last block number reported is only eventually consistent.