### PR TITLE
refactor(transfers): make handleTransfers more DRY

### DIFF
--- a/src/indexer/transfers.ts
+++ b/src/indexer/transfers.ts
@@ -1,70 +1,52 @@
 import { Contract, Event, indexEvents } from './index'
 
+interface ContractAndCurrency {
+  contract: Contract
+  currency: string
+}
+
+const TRANSFERS_TABLE_NAME = 'transfers'
+
 export async function handleTransfers() {
-  await indexEvents(
-    Contract.cUsd,
-    Event.Transfer,
-    'transfers',
-    ({ returnValues: { from, to, value } }) => ({
-      from,
-      to,
-      value,
+  const contractsAndCurrencies: ContractAndCurrency[] = [
+    {
+      contract: Contract.cUsd,
       currency: 'cUSD',
-    }),
-  )
-  await indexEvents(
-    Contract.cEur,
-    Event.Transfer,
-    'transfers',
-    ({ returnValues: { from, to, value } }) => ({
-      from,
-      to,
-      value,
+    },
+    {
+      contract: Contract.cEur,
       currency: 'cEUR',
-    }),
-  )
-  await indexEvents(
-    Contract.cReal,
-    Event.Transfer,
-    'transfers',
-    ({ returnValues: { from, to, value } }) => ({
-      from,
-      to,
-      value,
+    },
+    {
+      contract: Contract.cReal,
       currency: 'cREAL',
-    }),
-  )
-  await indexEvents(
-    Contract.mCUsd,
-    Event.Transfer,
-    'transfers',
-    ({ returnValues: { from, to, value } }) => ({
-      from,
-      to,
-      value,
+    },
+    {
+      contract: Contract.mCUsd,
       currency: 'mCUSD',
-    }),
-  )
-  await indexEvents(
-    Contract.mCEur,
-    Event.Transfer,
-    'transfers',
-    ({ returnValues: { from, to, value } }) => ({
-      from,
-      to,
-      value,
+    },
+    {
+      contract: Contract.mCEur,
       currency: 'mCEUR',
-    }),
-  )
-  await indexEvents(
-    Contract.mCReal,
-    Event.Transfer,
-    'transfers',
-    ({ returnValues: { from, to, value } }) => ({
-      from,
-      to,
-      value,
+    },
+    {
+      contract: Contract.mCReal,
       currency: 'mCREAL',
-    }),
+    },
+  ]
+  await Promise.all(
+    contractsAndCurrencies.map(({ contract, currency }) =>
+      indexEvents(
+        contract,
+        Event.Transfer,
+        TRANSFERS_TABLE_NAME,
+        ({ returnValues: { from, to, value } }) => ({
+          from,
+          to,
+          value,
+          currency,
+        }),
+      ),
+    ),
   )
 }

--- a/test/transfers.test.ts
+++ b/test/transfers.test.ts
@@ -1,0 +1,48 @@
+import { indexEvents } from '../src/indexer'
+import { mocked } from 'ts-jest/utils'
+import { handleTransfers } from '../src/indexer/transfers'
+
+jest.mock('../src/indexer')
+
+describe('handleTransfers', () => {
+  it('Indexes events for all supported tokens', async () => {
+    const mockPayload = {
+      returnValues: {
+        from: '0x123',
+        to: '0xabc',
+        value: '456',
+      },
+    }
+    const contractToCurrency = {
+      cUsd: 'cUSD',
+      cEur: 'cEUR',
+      cReal: 'cREAL',
+      mCUsd: 'mCUSD',
+      mCEur: 'mCEUR',
+      mCReal: 'mCREAL',
+    }
+    const indexEventsMock = jest
+      .fn()
+      .mockImplementation((contract, _event, _tableName, payloadMapper) => {
+        const mappedPayload = payloadMapper(mockPayload)
+        if (!(contract in contractToCurrency)) {
+          throw new Error(
+            `Contract ${contract} not found in contractToCurrency. Make sure to add it to get coverage on labels for indexed data.`,
+          )
+        }
+        const expectedCurrency =
+          contractToCurrency[contract as keyof typeof contractToCurrency]
+        expect(mappedPayload?.currency).toEqual(expectedCurrency)
+      })
+    mocked(indexEvents).mockImplementation(indexEventsMock)
+    await handleTransfers()
+    Object.keys(contractToCurrency).forEach((contract) => {
+      expect(indexEventsMock).toHaveBeenCalledWith(
+        contract,
+        'Transfer',
+        'transfers',
+        expect.any(Function),
+      )
+    })
+  })
+})

--- a/test/transfers.test.ts
+++ b/test/transfers.test.ts
@@ -14,6 +14,8 @@ describe('handleTransfers', () => {
       },
     }
     const contractToCurrency = {
+      // uses hardcoded keys like cUsd instead of Contract.cUsd because these shouldn't actually change. They're saved
+      //  to the DB and used in queries. So if a value in Contract changes, we want a test to fail.
       cUsd: 'cUSD',
       cEur: 'cEUR',
       cReal: 'cREAL',


### PR DESCRIPTION
depends on #26 

also probably more efficient, since it uses Promise.all instead of sequentially awaiting