### PR TITLE
feat(celo-transfers): index CELO transfers

### DIFF
--- a/src/indexer/index.ts
+++ b/src/indexer/index.ts
@@ -20,6 +20,7 @@ export enum Contract {
   mCUsd = 'mCUsd',
   mCEur = 'mCEur',
   mCReal = 'mCReal',
+  celo = 'celo',
 }
 
 // TODO: Add types for the events of each contract.
@@ -73,6 +74,10 @@ const contracts: { [contract in Contract]: ContractInfo } = {
   },
   [Contract.mCReal]: {
     contract: (kit) => kit.contracts.getErc20(MCREAL_ADDRESS!),
+    batchSize: 500,
+  },
+  [Contract.celo]: {
+    contract: (kit) => kit.contracts.getGoldToken(),
     batchSize: 500,
   },
 }

--- a/src/indexer/transfers.ts
+++ b/src/indexer/transfers.ts
@@ -33,6 +33,10 @@ export async function handleTransfers() {
       contract: Contract.mCReal,
       currency: 'mCREAL',
     },
+    {
+      contract: Contract.celo,
+      currency: 'CELO',
+    },
   ]
   await Promise.all(
     contractsAndCurrencies.map(({ contract, currency }) =>

--- a/src/indexer/transfers.ts
+++ b/src/indexer/transfers.ts
@@ -1,70 +1,52 @@
 import { Contract, Event, indexEvents } from './index'
 
+interface ContractAndCurrency {
+  contract: Contract
+  currency: string
+}
+
+const TRANSFERS_TABLE_NAME = 'transfers'
+
 export async function handleTransfers() {
-  await indexEvents(
-    Contract.cUsd,
-    Event.Transfer,
-    'transfers',
-    ({ returnValues: { from, to, value } }) => ({
-      from,
-      to,
-      value,
+  const contractsAndCurrencies: ContractAndCurrency[] = [
+    {
+      contract: Contract.cUsd,
       currency: 'cUSD',
-    }),
-  )
-  await indexEvents(
-    Contract.cEur,
-    Event.Transfer,
-    'transfers',
-    ({ returnValues: { from, to, value } }) => ({
-      from,
-      to,
-      value,
+    },
+    {
+      contract: Contract.cEur,
       currency: 'cEUR',
-    }),
-  )
-  await indexEvents(
-    Contract.cReal,
-    Event.Transfer,
-    'transfers',
-    ({ returnValues: { from, to, value } }) => ({
-      from,
-      to,
-      value,
+    },
+    {
+      contract: Contract.cReal,
       currency: 'cREAL',
-    }),
-  )
-  await indexEvents(
-    Contract.mCUsd,
-    Event.Transfer,
-    'transfers',
-    ({ returnValues: { from, to, value } }) => ({
-      from,
-      to,
-      value,
+    },
+    {
+      contract: Contract.mCUsd,
       currency: 'mCUSD',
-    }),
-  )
-  await indexEvents(
-    Contract.mCEur,
-    Event.Transfer,
-    'transfers',
-    ({ returnValues: { from, to, value } }) => ({
-      from,
-      to,
-      value,
+    },
+    {
+      contract: Contract.mCEur,
       currency: 'mCEUR',
-    }),
-  )
-  await indexEvents(
-    Contract.mCReal,
-    Event.Transfer,
-    'transfers',
-    ({ returnValues: { from, to, value } }) => ({
-      from,
-      to,
-      value,
+    },
+    {
+      contract: Contract.mCReal,
       currency: 'mCREAL',
-    }),
+    },
+  ]
+  await Promise.all(
+    contractsAndCurrencies.map(({ contract, currency }) =>
+      indexEvents(
+        contract,
+        Event.Transfer,
+        TRANSFERS_TABLE_NAME,
+        ({ returnValues: { from, to, value } }) => ({
+          from,
+          to,
+          value,
+          currency,
+        }),
+      ),
+    ),
   )
 }

--- a/test/transfers.test.ts
+++ b/test/transfers.test.ts
@@ -22,6 +22,7 @@ describe('handleTransfers', () => {
       mCUsd: 'mCUSD',
       mCEur: 'mCEUR',
       mCReal: 'mCREAL',
+      celo: 'CELO',
     }
     const indexEventsMock = jest
       .fn()

--- a/test/transfers.test.ts
+++ b/test/transfers.test.ts
@@ -1,0 +1,48 @@
+import { indexEvents } from '../src/indexer'
+import { mocked } from 'ts-jest/utils'
+import { handleTransfers } from '../src/indexer/transfers'
+
+jest.mock('../src/indexer')
+
+describe('handleTransfers', () => {
+  it('Indexes events for all supported tokens', async () => {
+    const mockPayload = {
+      returnValues: {
+        from: '0x123',
+        to: '0xabc',
+        value: '456',
+      },
+    }
+    const contractToCurrency = {
+      cUsd: 'cUSD',
+      cEur: 'cEUR',
+      cReal: 'cREAL',
+      mCUsd: 'mCUSD',
+      mCEur: 'mCEUR',
+      mCReal: 'mCREAL',
+    }
+    const indexEventsMock = jest
+      .fn()
+      .mockImplementation((contract, _event, _tableName, payloadMapper) => {
+        const mappedPayload = payloadMapper(mockPayload)
+        if (!(contract in contractToCurrency)) {
+          throw new Error(
+            `Contract ${contract} not found in contractToCurrency. Make sure to add it to get coverage on labels for indexed data.`,
+          )
+        }
+        const expectedCurrency =
+          contractToCurrency[contract as keyof typeof contractToCurrency]
+        expect(mappedPayload?.currency).toEqual(expectedCurrency)
+      })
+    mocked(indexEvents).mockImplementation(indexEventsMock)
+    await handleTransfers()
+    Object.keys(contractToCurrency).forEach((contract) => {
+      expect(indexEventsMock).toHaveBeenCalledWith(
+        contract,
+        'Transfer',
+        'transfers',
+        expect.any(Function),
+      )
+    })
+  })
+})

--- a/test/transfers.test.ts
+++ b/test/transfers.test.ts
@@ -14,6 +14,8 @@ describe('handleTransfers', () => {
       },
     }
     const contractToCurrency = {
+      // uses hardcoded keys like cUsd instead of Contract.cUsd because these shouldn't actually change. They're saved
+      //  to the DB and used in queries. So if a value in Contract changes, we want a test to fail.
       cUsd: 'cUSD',
       cEur: 'cEUR',
       cReal: 'cREAL',


### PR DESCRIPTION
relies on #26 and #27

## Testing

- unit test coverage for handleTransfers
- ran locally for a while and indexed some celo transfers, looked fine.

## Caveats on data incompleteness

there is some weirdness to this, because you can actually transfer CELO in 2 ways:
- by interacting with the ERC20 contract (which will emit events that are indexed)
- by specifying a "value" field in a transaction

reference [here](https://docs.celo.org/developer/migrate/from-ethereum#:~:text=CELO%20has%20an%20ERC20%20interface,go%20through%20the%20token%20contract.)

So we need to be careful in the assumptions we make about what this data really represents, since it's incomplete. 

I think we make the assumption elsewhere-- like in blockchain-api-- that the smart contract CELO transfers are the only ones to worry about, so my hope is that the vast majority of CELO transfers use the smart contract. But I don't have data to support that at this time.

I suggest we merge this and just be careful about data consumption until the question is resolved. Created a Linear issue for further investigation [here](https://linear.app/valora/issue/ACT-566/spike-celo-transfer-data-incompleteness)