### PR TITLE
feat: add timestamp to indexed events

### DIFF
--- a/src/indexer/index.ts
+++ b/src/indexer/index.ts
@@ -139,7 +139,7 @@ export async function indexEvents(
               logIndex,
               blockNumber,
               blockHash,
-              timestamp: blockNumberToTimestamp[blockNumber],
+              blockTimestamp: blockNumberToTimestamp[blockNumber],
               ...payloadMapper(event),
             })
             .transacting(trx)

--- a/src/indexer/index.ts
+++ b/src/indexer/index.ts
@@ -82,10 +82,12 @@ const contracts: { [contract in Contract]: ContractInfo } = {
   },
 }
 
-async function getBlockTimestamps(events: EventLog[], kit: ContractKit) {
+// Exported to allow for testing
+export async function getBlockTimestamps(events: EventLog[], kit: ContractKit) {
   const blockNumberToTimestamp: Record<number, number> = {}
-  const uniqueBlockNumbers = new Set<number>()
-  events.forEach((event) => uniqueBlockNumbers.add(event.blockNumber))
+  const uniqueBlockNumbers = new Set(
+    events.map(({ blockNumber }) => blockNumber),
+  )
   await Promise.all(
     Array.from(uniqueBlockNumbers).map(async (blockNumber) => {
       const block = await kit.web3.eth.getBlock(blockNumber)

--- a/src/indexer/index.ts
+++ b/src/indexer/index.ts
@@ -84,8 +84,10 @@ const contracts: { [contract in Contract]: ContractInfo } = {
 
 async function getBlockTimestamps(events: EventLog[], kit: ContractKit) {
   const blockNumberToTimestamp: Record<number, number> = {}
+  const uniqueBlockNumbers = new Set<number>()
+  events.forEach((event) => uniqueBlockNumbers.add(event.blockNumber))
   await Promise.all(
-    events.map(async ({ blockNumber }) => {
+    Array.from(uniqueBlockNumbers).map(async (blockNumber) => {
       const block = await kit.web3.eth.getBlock(blockNumber)
       blockNumberToTimestamp[blockNumber] = Number(block.timestamp)
     }),

--- a/src/migrations/20230221212034_CreateTimestamp.ts
+++ b/src/migrations/20230221212034_CreateTimestamp.ts
@@ -12,7 +12,7 @@ export async function up(knex: Knex): Promise<void> {
     TABLE_NAMES.map(
       async (tableName) =>
         await knex.schema.alterTable(tableName, (table) =>
-          table.bigInteger('timestamp'),
+          table.bigInteger('blockTimestamp'),
         ),
     ),
   )
@@ -23,7 +23,7 @@ export async function down(knex: Knex): Promise<void> {
     TABLE_NAMES.map(
       async (tableName) =>
         await knex.schema.alterTable(tableName, (table) =>
-          table.dropColumn('timestamp'),
+          table.dropColumn('blockTimestamp'),
         ),
     ),
   )

--- a/src/migrations/20230221212034_CreateTimestamp.ts
+++ b/src/migrations/20230221212034_CreateTimestamp.ts
@@ -1,0 +1,22 @@
+import { Knex } from 'knex'
+
+export async function up(knex: Knex): Promise<void> {
+  const tableNames: string[] = [
+    'account_wallet_mappings',
+    'attestations_completed',
+    'escrow',
+    'transfers',
+  ]
+  await Promise.all(
+    tableNames.map(
+      async (tableName) =>
+        await knex.schema.alterTable(tableName, (table) =>
+          table.bigInteger('timestamp'),
+        ),
+    ),
+  )
+}
+
+export async function down(knex: Knex): Promise<void> {
+  throw new Error('Unable to revert migration')
+}

--- a/src/migrations/20230221212034_CreateTimestamp.ts
+++ b/src/migrations/20230221212034_CreateTimestamp.ts
@@ -1,7 +1,7 @@
 import { Knex } from 'knex'
 
 export async function up(knex: Knex): Promise<void> {
-  const tableNames: string[] = [
+  const tableNames = [
     'account_wallet_mappings',
     'attestations_completed',
     'escrow',

--- a/src/migrations/20230221212034_CreateTimestamp.ts
+++ b/src/migrations/20230221212034_CreateTimestamp.ts
@@ -1,14 +1,15 @@
 import { Knex } from 'knex'
 
+const TABLE_NAMES = [
+  'account_wallet_mappings',
+  'attestations_completed',
+  'escrow',
+  'transfers',
+]
+
 export async function up(knex: Knex): Promise<void> {
-  const tableNames = [
-    'account_wallet_mappings',
-    'attestations_completed',
-    'escrow',
-    'transfers',
-  ]
   await Promise.all(
-    tableNames.map(
+    TABLE_NAMES.map(
       async (tableName) =>
         await knex.schema.alterTable(tableName, (table) =>
           table.bigInteger('timestamp'),
@@ -18,5 +19,12 @@ export async function up(knex: Knex): Promise<void> {
 }
 
 export async function down(knex: Knex): Promise<void> {
-  throw new Error('Unable to revert migration')
+  await Promise.all(
+    TABLE_NAMES.map(
+      async (tableName) =>
+        await knex.schema.alterTable(tableName, (table) =>
+          table.dropColumn('timestamp'),
+        ),
+    ),
+  )
 }

--- a/test/indexer.test.ts
+++ b/test/indexer.test.ts
@@ -6,9 +6,7 @@ import { getContractKit } from '../src/util/utils'
 
 const getLastBlockNumberMock = jest.fn()
 const getAccountEventsMock = jest.fn()
-
-const timestamp = 10000
-const getBlockMock = jest.fn().mockResolvedValue({timestamp})
+const getBlockMock = jest.fn()
 
 jest.mock('../src/util/utils', () => ({
   getContractKit: jest.fn(() => ({
@@ -52,6 +50,7 @@ describe('Indexer', () => {
     getAccountEventsMock
       .mockImplementationOnce(() => [partialEventLog({ transactionHash: firstTxHash })])
       .mockImplementationOnce(() => [partialEventLog({ transactionHash: secondTxHash })])
+    getBlockMock.mockImplementation((blockNumber) => ({timestamp: blockNumber}))
   }
 
   it('indexes account events', async () => {
@@ -100,7 +99,7 @@ describe('Indexer', () => {
     const kit = await getContractKit()
     const blockNumberToTimestamp = await getBlockTimestamps([partialEventLog({blockNumber: blockNumber1}), partialEventLog({blockNumber: blockNumber2})], kit)
 
-    expect(blockNumberToTimestamp).toEqual({[blockNumber1]: timestamp, [blockNumber2]: timestamp})
+    expect(blockNumberToTimestamp).toEqual({[blockNumber1]: blockNumber1, [blockNumber2]: blockNumber2})
     expect(getBlockMock).toHaveBeenCalledTimes(2)
   })
 
@@ -109,7 +108,7 @@ describe('Indexer', () => {
     const kit = await getContractKit()
     const blockNumberToTimestamp = await getBlockTimestamps([partialEventLog({blockNumber}), partialEventLog({blockNumber})], kit)
 
-    expect(blockNumberToTimestamp).toEqual({[blockNumber]: timestamp})
+    expect(blockNumberToTimestamp).toEqual({[blockNumber]: blockNumber})
     expect(getBlockMock).toHaveBeenCalledTimes(1)
   })
 })

--- a/test/indexer.test.ts
+++ b/test/indexer.test.ts
@@ -11,6 +11,7 @@ jest.mock('../src/util/utils', () => ({
     web3: {
       eth: {
         getBlockNumber: getLastBlockNumberMock,
+        getBlock: jest.fn().mockReturnValue(12345)
       },
     },
     contracts: {


### PR DESCRIPTION
Currently, the indexer does not store the timestamp associated with blockchain events. As part of [ACT-612](https://linear.app/valora/issue/ACT-612/add-time-field-to-valora-transfer-events), this PR adds this functionality and updates the database schema as required.