### PR TITLE
feat(local-dev): script to add mock data

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,10 +13,16 @@ yarn
 
 ## Running locally
 
-Run a local PostgreSQL instance. For example:
+Run a local PostgreSQL instance:
 
 ```
-docker run --rm -p 5432:5432 -e POSTGRES_DB=indexer -e POSTGRES_PASSWORD=docker postgres
+yarn run-local-db
+```
+
+If you want to test "normal behavior", where the indexer is all caught up to the latest data, you can simulate this
+by running the add-mock-data script:
+```
+yarn add-mock-data
 ```
 
 Start the indexer:

--- a/package.json
+++ b/package.json
@@ -14,6 +14,8 @@
     "format": "prettier --loglevel error --write \"./{src,bin/test}/**/*.ts\"",
     "lint": "eslint --ext=.tsx,.ts src/ test/ bin/",
     "e2e": "node e2e/run.js",
+    "run-local-db": "docker run --rm -p 5432:5432 -e POSTGRES_DB=indexer -e POSTGRES_PASSWORD=docker postgres",
+    "add-mock-data": "ts-node ./scripts/add-mock-recent-data.ts",
     "start": "node ./dist/bin/indexer.js",
     "start:local": "yarn build && cp config/config.local.env .env && node --inspect ./dist/bin/indexer.js"
   },
@@ -55,6 +57,7 @@
     "prettier": "^2.3.2",
     "sqlite3": "^5.0.2",
     "ts-jest": "^27.0.4",
+    "ts-node": "^10.9.1",
     "typescript": "~4.3.2"
   },
   "peerDependencies": {

--- a/scripts/add-mock-recent-data.ts
+++ b/scripts/add-mock-recent-data.ts
@@ -1,0 +1,61 @@
+/**
+ * Add mock data to the local indexer database to simulate running an up-to-date indexer.
+ *
+ * Otherwise running the indexer locally tests what the indexer does to catch up after falling far behind,
+ *   which is different than the average case when the indexer is running normally and its db is relatively up to date.
+ */
+
+import { database, initDatabase } from '../src/database/db'
+import {
+  BLOCK_METADATA_TABLE_NAME,
+  BLOCK_NUMBER_COL_NAME,
+  BLOCK_TIMESTAMP_COL_NAME,
+} from '../src/indexer/block-metadata'
+import { getContractKit } from '../src/util/utils'
+import { LAST_BLOCKS_TABLE_NAME } from '../src/indexer/blocks'
+import * as process from 'process'
+import { contractsAndCurrencies } from '../src/indexer/transfers'
+
+async function main() {
+  await initDatabase()
+
+  // block metadata
+  const contractKit = await getContractKit()
+  const currentBlockNumber = await contractKit.web3.eth.getBlockNumber()
+  const blockTimestamp = Number(
+    (await contractKit.web3.eth.getBlock(currentBlockNumber)).timestamp,
+  )
+  await database(BLOCK_METADATA_TABLE_NAME)
+    .insert({
+      [BLOCK_NUMBER_COL_NAME]: currentBlockNumber,
+      [BLOCK_TIMESTAMP_COL_NAME]: blockTimestamp,
+    })
+    .onConflict(BLOCK_NUMBER_COL_NAME)
+    .ignore() // do nothing if row already exists with same blockNumber
+
+  // events
+  for (const key of [
+    'Escrow_Withdrawal',
+    'Escrow_Transfer',
+    'Escrow_Revocation',
+    'Accounts_AccountWalletAddressSet',
+    'Attestations_AttestationCompleted',
+  ].concat(
+    contractsAndCurrencies.map(({ contract }) => `${contract}_Transfer`),
+  )) {
+    await database(LAST_BLOCKS_TABLE_NAME)
+      .insert({
+        key,
+        lastBlock: currentBlockNumber,
+      })
+      .onConflict('key')
+      .merge() // overwrite if exists
+  }
+}
+
+main()
+  .catch(console.error)
+  .then(() => {
+    console.log('done adding mock data to db')
+    process.exit(0)
+  })

--- a/src/indexer/block-metadata.ts
+++ b/src/indexer/block-metadata.ts
@@ -2,9 +2,9 @@ import { database } from '../database/db'
 import { getContractKit } from '../util/utils'
 import { BLOCK_METADATA_DEFAULT_MIN_BLOCK_NUMBER } from '../config'
 
-const BLOCK_METADATA_TABLE_NAME = 'block_metadata'
-const BLOCK_NUMBER_COL_NAME = 'blockNumber'
-const BLOCK_TIMESTAMP_COL_NAME = 'blockTimestamp'
+export const BLOCK_METADATA_TABLE_NAME = 'block_metadata'
+export const BLOCK_NUMBER_COL_NAME = 'blockNumber'
+export const BLOCK_TIMESTAMP_COL_NAME = 'blockTimestamp'
 
 export async function handleBlockMetadata() {
   try {

--- a/src/indexer/blocks.ts
+++ b/src/indexer/blocks.ts
@@ -1,14 +1,14 @@
 import { database } from '../database/db'
 
-const TABLE_NAME = 'last_blocks'
+export const LAST_BLOCKS_TABLE_NAME = 'last_blocks'
 
 export async function getLastBlock(key: string) {
-  const row = await database(TABLE_NAME).where({ key }).first()
+  const row = await database(LAST_BLOCKS_TABLE_NAME).where({ key }).first()
   return row?.lastBlock ?? 0
 }
 
 export function setLastBlock(key: string, block: number) {
-  return database(TABLE_NAME)
+  return database(LAST_BLOCKS_TABLE_NAME)
     .insert({ key, lastBlock: block })
     .onConflict('key')
     .merge()

--- a/src/indexer/transfers.ts
+++ b/src/indexer/transfers.ts
@@ -7,37 +7,37 @@ interface ContractAndCurrency {
 
 const TRANSFERS_TABLE_NAME = 'transfers'
 
+export const contractsAndCurrencies: ContractAndCurrency[] = [
+  {
+    contract: Contract.cUsd,
+    currency: 'cUSD',
+  },
+  {
+    contract: Contract.cEur,
+    currency: 'cEUR',
+  },
+  {
+    contract: Contract.cReal,
+    currency: 'cREAL',
+  },
+  {
+    contract: Contract.mCUsd,
+    currency: 'mCUSD',
+  },
+  {
+    contract: Contract.mCEur,
+    currency: 'mCEUR',
+  },
+  {
+    contract: Contract.mCReal,
+    currency: 'mCREAL',
+  },
+  {
+    contract: Contract.celo,
+    currency: 'CELO',
+  },
+]
 export async function handleTransfers() {
-  const contractsAndCurrencies: ContractAndCurrency[] = [
-    {
-      contract: Contract.cUsd,
-      currency: 'cUSD',
-    },
-    {
-      contract: Contract.cEur,
-      currency: 'cEUR',
-    },
-    {
-      contract: Contract.cReal,
-      currency: 'cREAL',
-    },
-    {
-      contract: Contract.mCUsd,
-      currency: 'mCUSD',
-    },
-    {
-      contract: Contract.mCEur,
-      currency: 'mCEUR',
-    },
-    {
-      contract: Contract.mCReal,
-      currency: 'mCREAL',
-    },
-    {
-      contract: Contract.celo,
-      currency: 'CELO',
-    },
-  ]
   await Promise.all(
     contractsAndCurrencies.map(({ contract, currency }) =>
       indexEvents(

--- a/yarn.lock
+++ b/yarn.lock
@@ -573,6 +573,13 @@
   dependencies:
     arrify "^1.0.1"
 
+"@cspotcode/source-map-support@^0.8.0":
+  version "0.8.1"
+  resolved "https://registry.yarnpkg.com/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz#00629c35a688e05a88b1cda684fb9d5e73f000a1"
+  integrity sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==
+  dependencies:
+    "@jridgewell/trace-mapping" "0.3.9"
+
 "@eslint/eslintrc@^0.4.2":
   version "0.4.2"
   resolved "https://registry.yarnpkg.com/@eslint/eslintrc/-/eslintrc-0.4.2.tgz#f63d0ef06f5c0c57d76c4ab5f63d3835c51b0179"
@@ -1126,6 +1133,24 @@
     "@types/yargs" "^16.0.0"
     chalk "^4.0.0"
 
+"@jridgewell/resolve-uri@^3.0.3":
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/@jridgewell/resolve-uri/-/resolve-uri-3.1.1.tgz#c08679063f279615a3326583ba3a90d1d82cc721"
+  integrity sha512-dSYZh7HhCDtCKm4QakX0xFpsRDqjjtZf/kjI/v3T3Nwt5r8/qz/M19F9ySyOqU94SXBmeG9ttTul+YnR4LOxFA==
+
+"@jridgewell/sourcemap-codec@^1.4.10":
+  version "1.4.15"
+  resolved "https://registry.yarnpkg.com/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.15.tgz#d7c6e6755c78567a951e04ab52ef0fd26de59f32"
+  integrity sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg==
+
+"@jridgewell/trace-mapping@0.3.9":
+  version "0.3.9"
+  resolved "https://registry.yarnpkg.com/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz#6534fd5933a53ba7cbf3a17615e273a0d1273ff9"
+  integrity sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==
+  dependencies:
+    "@jridgewell/resolve-uri" "^3.0.3"
+    "@jridgewell/sourcemap-codec" "^1.4.10"
+
 "@ladjs/time-require@^0.1.4":
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/@ladjs/time-require/-/time-require-0.1.4.tgz#5c615d75fd647ddd5de9cf6922649558856b21a1"
@@ -1322,6 +1347,26 @@
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/@tootallnate/once/-/once-1.1.2.tgz#ccb91445360179a04e7fe6aff78c00ffc1eeaf82"
   integrity sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==
+
+"@tsconfig/node10@^1.0.7":
+  version "1.0.9"
+  resolved "https://registry.yarnpkg.com/@tsconfig/node10/-/node10-1.0.9.tgz#df4907fc07a886922637b15e02d4cebc4c0021b2"
+  integrity sha512-jNsYVVxU8v5g43Erja32laIDHXeoNvFEpX33OK4d6hljo3jDhCBDhx5dhCCTMWUojscpAagGiRkBKxpdl9fxqA==
+
+"@tsconfig/node12@^1.0.7":
+  version "1.0.11"
+  resolved "https://registry.yarnpkg.com/@tsconfig/node12/-/node12-1.0.11.tgz#ee3def1f27d9ed66dac6e46a295cffb0152e058d"
+  integrity sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==
+
+"@tsconfig/node14@^1.0.0":
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/@tsconfig/node14/-/node14-1.0.3.tgz#e4386316284f00b98435bf40f72f75a09dabf6c1"
+  integrity sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==
+
+"@tsconfig/node16@^1.0.2":
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/@tsconfig/node16/-/node16-1.0.4.tgz#0b92dcc0cc1c81f6f306a381f28e31b1a56536e9"
+  integrity sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==
 
 "@types/async-polling@^0.0.3":
   version "0.0.3"
@@ -1772,6 +1817,11 @@ acorn-walk@^7.1.1:
   resolved "https://registry.yarnpkg.com/acorn-walk/-/acorn-walk-7.2.0.tgz#0de889a601203909b0fbe07b8938dc21d2e967bc"
   integrity sha512-OPdCF6GsMIP+Az+aWfAAOEt2/+iVDKE7oy6lJ098aoe59oAmK76qV6Gw60SbZ8jHuG2wH058GF4pLFbYamYrVA==
 
+acorn-walk@^8.1.1:
+  version "8.2.0"
+  resolved "https://registry.yarnpkg.com/acorn-walk/-/acorn-walk-8.2.0.tgz#741210f2e2426454508853a2f44d0ab83b7f69c1"
+  integrity sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==
+
 acorn@^7.1.1, acorn@^7.4.0:
   version "7.4.1"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-7.4.1.tgz#feaed255973d2e77555b83dbc08851a6c63520fa"
@@ -1781,6 +1831,11 @@ acorn@^8.2.4:
   version "8.4.1"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.4.1.tgz#56c36251fc7cabc7096adc18f05afe814321a28c"
   integrity sha512-asabaBSkEKosYKMITunzX177CXxQ4Q8BSSzMTKD+FefUhipQC70gfW5SiUDhYQ3vk8G+81HqQk7Fv9OXwwn9KA==
+
+acorn@^8.4.1:
+  version "8.10.0"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.10.0.tgz#8be5b3907a67221a81ab23c7889c4c5526b62ec5"
+  integrity sha512-F0SAmZ8iUtS//m8DmCTA0jlh6TDKkHQyK6xc6V4KDTyZKA9dnvX9/3sRTVQrWm79glUAZbnmmNcdYwUIHWVybw==
 
 agent-base@6:
   version "6.0.2"
@@ -3748,6 +3803,11 @@ create-hmac@^1.1.0, create-hmac@^1.1.2, create-hmac@^1.1.4, create-hmac@^1.1.7:
     ripemd160 "^2.0.0"
     safe-buffer "^5.0.1"
     sha.js "^2.4.8"
+
+create-require@^1.1.0:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/create-require/-/create-require-1.1.1.tgz#c1d7e8f1e5f6cfc9ff65f9cd352d37348756c333"
+  integrity sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==
 
 cross-fetch@^3.0.6:
   version "3.1.5"
@@ -11277,6 +11337,25 @@ ts-jest@^27.0.4:
     semver "7.x"
     yargs-parser "20.x"
 
+ts-node@^10.9.1:
+  version "10.9.1"
+  resolved "https://registry.yarnpkg.com/ts-node/-/ts-node-10.9.1.tgz#e73de9102958af9e1f0b168a6ff320e25adcff4b"
+  integrity sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==
+  dependencies:
+    "@cspotcode/source-map-support" "^0.8.0"
+    "@tsconfig/node10" "^1.0.7"
+    "@tsconfig/node12" "^1.0.7"
+    "@tsconfig/node14" "^1.0.0"
+    "@tsconfig/node16" "^1.0.2"
+    acorn "^8.4.1"
+    acorn-walk "^8.1.1"
+    arg "^4.1.0"
+    create-require "^1.1.0"
+    diff "^4.0.1"
+    make-error "^1.1.1"
+    v8-compile-cache-lib "^3.0.1"
+    yn "3.1.1"
+
 ts-node@^8.4.1:
   version "8.5.4"
   resolved "https://registry.yarnpkg.com/ts-node/-/ts-node-8.5.4.tgz#a152add11fa19c221d0b48962c210cf467262ab2"
@@ -11632,6 +11711,11 @@ uuid@^8.3.2:
   version "8.3.2"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.2.tgz#80d5b5ced271bb9af6c445f21a1a04c606cefbe2"
   integrity sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==
+
+v8-compile-cache-lib@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz#6336e8d71965cb3d35a1bbb7868445a7c05264bf"
+  integrity sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==
 
 v8-compile-cache@^2.0.3:
   version "2.3.0"
@@ -12428,6 +12512,11 @@ yargs@~3.10.0:
     cliui "^2.1.0"
     decamelize "^1.0.0"
     window-size "0.1.0"
+
+yn@3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/yn/-/yn-3.1.1.tgz#1e87401a09d767c1d5eab26a6e4c185182d2eb50"
+  integrity sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==
 
 yn@^3.0.0:
   version "3.1.0"


### PR DESCRIPTION
to test locally with an indexer that is "all caught up"

I did this because I wanted to see if an up-to-date indexer could use forno again, and avoid using up QuickNode quota, which we are running low on and about to get charged extra for overages. Previously we hit rate limits with forno for two reasons:
1. we were querying forno many times per block in quick succession to get block timestamps (now we do this once per block, and more slowly)
2. we fell several days behind. the indexer tries to catch up too quickly for forno's rate limits

to switch to forno safely, we'll probably also need to add alerting for when the indexer starts running behind and a runbook explaining that an on-call engineer should switch us back to QuickNode to catch up