### PR TITLE
ci(cd): allow manual workflow dispatch

### DIFF
--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -7,6 +7,8 @@ on:
       - main
   # ..and any pull request.
   pull_request:
+  # Allow manual triggers (required to refresh secrets/env vars)
+  workflow_dispatch:
 
 # This serializes deploys from main.
 concurrency:


### PR DESCRIPTION
trying to make it easier to switch between forno and quicknode