### PR TITLE
docs(operations): adding operations doc for troubleshooting

### DIFF
--- a/operations.md
+++ b/operations.md
@@ -13,9 +13,14 @@ intervention.
 
 #### Symptoms
 
-Errors like this in the logs:
+You should see logs [here](https://console.cloud.google.com/logs/query;query=resource.type%3D%22gae_app%22%0Aresource.labels.module_id%3D%22indexer%22%0AtextPayload%3D~%22rate%20limit%22?project=celo-mobile-mainnet) related to rate limiting.
 
-TODO
+In case the link doesn't work, you can open Logs Explorer on the GCP console and paste the following query:
+```
+resource.type="gae_app"
+resource.labels.module_id="indexer"
+textPayload=~"rate limit"
+```
 
 #### Troubleshooting
 

--- a/operations.md
+++ b/operations.md
@@ -35,3 +35,4 @@ To change the web3 provider to QuickNode:
 - find the web3 provider url from the QuickNode dashboard. At time of writing the endpoint is located [here](https://dashboard.quicknode.com/endpoints/166850), see "HTTP Provider"
   - if you cannot access the QuickNode dashboard, ask an admin to add you. At time of writing, admins included Satish, Kathy, Silas, Charlie, Joe, and Jean.
 - add `WEB3_PROVIDER_URL` to [indexer-secrets](https://console.cloud.google.com/security/secret-manager/secret/indexer-secrets/versions?project=celo-mobile-mainnet)
+- redeploy the indexer for the changes to take effect

--- a/operations.md
+++ b/operations.md
@@ -1,0 +1,32 @@
+# Indexer Operations
+
+This document is intended to help engineers maintain the indexer and solve related on-call issues.
+
+## Expected issues
+
+### Web3 provider rate limits
+
+The indexer pulls blockchain data from a full node aka web3 provider. We have seen the indexer exceed rate limits on 
+our web3 provider in the past which brought the service to a halt, affecting analytics (no valora user transfer 
+events going to BQ, Mixpanel, or Statsig). Retries along were not sufficient for the issue to go away without 
+intervention.
+
+#### Symptoms
+
+Errors like this in the logs:
+
+TODO
+
+#### Troubleshooting
+
+We may choose to use Forno as a web3 provider to save on cost. That being said, the indexer works well using QuickNode 
+as a web3 provider, even when coming back from a several day pause. If rate limit issues are seen with Forno, consider 
+changing the web3 provider to QuickNode. 
+
+Note that QuickNode includes an API key in the web3 provider URL, so it is stored as a secret.
+
+To change the web3 provider to QuickNode:
+- delete `WEB3_PROVIDER_URL` from [app.mainnet.yaml](https://github.com/valora-inc/indexer/blob/bcd3d59a6ca622de528bcbc59a4ccb80cb78c631/app.mainnet.yaml#L6) if it is set there
+- find the web3 provider url from the QuickNode dashboard. At time of writing the endpoint is located [here](https://dashboard.quicknode.com/endpoints/166850), see "HTTP Provider"
+  - if you cannot access the QuickNode dashboard, ask an admin to add you. At time of writing, admins included Satish, Kathy, Silas, Charlie, Joe, and Jean.
+- add `WEB3_PROVIDER_URL` to [indexer-secrets](https://console.cloud.google.com/security/secret-manager/secret/indexer-secrets/versions?project=celo-mobile-mainnet)


### PR DESCRIPTION
running the indexer locally with forno works, so I want to switch it back to forno to save on cost, since we are set to exceed our QuickNode quota by a lot. But if the indexer stops again, here are instructions for getting it back on QuickNode.