### PR TITLE
chore(monitoring): add blocksBehind, blockWithinRange fields to status endpoint

### DIFF
--- a/e2e/run.js
+++ b/e2e/run.js
@@ -1,5 +1,6 @@
 const { spawn, spawnSync } = require('child_process')
 const db = require('./db')
+const fetch = require('node-fetch')
 
 const debug = false
 const createPostgresContainer = true
@@ -113,6 +114,16 @@ async function main() {
   console.log('Waiting for DB to have some contents...')
   const rows = await db.psql('SELECT * FROM transfers LIMIT 1;', 30)
   console.log(`DB has some contents: ${JSON.stringify(rows, null, 2)}`)
+
+  console.log('Fetching indexer status')
+  const statusResponse = await fetch('http://localhost:8080/status')
+  const { blocksBehind } = await statusResponse.json()
+  if (!blocksBehind || blocksBehind <= 0) {
+    throw new Error(
+      'blocksBehind should be greater than 0 for indexer that just started from block 1',
+    )
+  }
+  console.log(`Indexer is ${blocksBehind} blocks behind`)
 
   // TODO: run more checks on the DB to ensure things look reasonable.
   process.exit(0)

--- a/e2e/run.js
+++ b/e2e/run.js
@@ -117,13 +117,28 @@ async function main() {
 
   console.log('Fetching indexer status')
   const statusResponse = await fetch('http://localhost:8080/status')
-  const { blocksBehind } = await statusResponse.json()
+  const { blocksBehind, blockWithinRange } = await statusResponse.json()
+  console.log(`Indexer is ${blocksBehind} blocks behind`)
   if (!blocksBehind || blocksBehind <= 0) {
     throw new Error(
       'blocksBehind should be greater than 0 for indexer that just started from block 1',
     )
   }
-  console.log(`Indexer is ${blocksBehind} blocks behind`)
+  if (blockWithinRange === undefined || blockWithinRange === true) {
+    throw new Error(
+      'blockWithinRange should be false for indexer that just started from block 1',
+    )
+  }
+
+  const statusResponse2 = await fetch(
+    'http://localhost:8080/status?max_blocks_behind=10000000000', // should not get here for another 1,582 years
+  )
+  const { blockWithinRange: blockWithinRange2 } = await statusResponse2.json()
+  if (!blockWithinRange2) {
+    throw new Error(
+      `blockWithinRange should be true for extremely high max_blocks_behind`,
+    )
+  }
 
   // TODO: run more checks on the DB to ensure things look reasonable.
   process.exit(0)

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,7 @@ import express from 'express'
 import { ENVIRONMENT, PORT, VERSION } from './config'
 import { initDatabase } from './database/db'
 import { pollers } from './polling'
+import { getStatusHandler } from './status'
 
 export default async function initApp(): Promise<express.Application> {
   console.info(
@@ -26,14 +27,7 @@ export default async function initApp(): Promise<express.Application> {
   app.get('/', (req: any, res: any) => {
     res.send('Celo Indexer. See /status for details.')
   })
-  app.get('/status', (req: any, res: any) => {
-    res.status(200).json({
-      version: VERSION,
-      serviceStartTime: new Date(START_TIME).toUTCString(),
-      serviceRunDuration:
-        Math.floor((Date.now() - START_TIME) / 60000) + ' minutes',
-    })
-  })
+  app.get('/status', getStatusHandler(START_TIME))
   app.get('/_ah/start', (req: any, res: any) => {
     res.status(200).end()
   })

--- a/src/status.ts
+++ b/src/status.ts
@@ -6,22 +6,32 @@ import { getContractKit } from './util/utils'
 import { Request, Response } from 'express'
 import { asyncRoute } from './util/async-route'
 
+const BLOCKS_PER_MINUTE = 12
+export const DEFAULT_MAX_BLOCKS_BEHIND = BLOCKS_PER_MINUTE * 120 // 2 hours
+
 export function getStatusHandler(startTime: number) {
-  return asyncRoute(async (_req: Request, res: Response) => {
+  return asyncRoute(async (req: Request, res: Response) => {
+    const maxBlocksBehind = req.query?.max_blocks_behind
+      ? parseInt(req.query.max_blocks_behind.toString())
+      : DEFAULT_MAX_BLOCKS_BEHIND
+
     const kit = await getContractKit()
     const curBlockNumber = await kit.web3.eth.getBlockNumber()
     const minTransferLastBlock = await database(LAST_BLOCKS_TABLE_NAME)
       .min('lastBlock as minLastBlock')
       .where('key', 'like', `%_${Event.Transfer}`)
 
+    const blocksBehind = minTransferLastBlock.length
+      ? curBlockNumber - (minTransferLastBlock[0].minLastBlock ?? 0)
+      : curBlockNumber
+
     res.status(200).json({
       version: VERSION,
       serviceStartTime: new Date(startTime).toUTCString(),
       serviceRunDuration:
         Math.floor((Date.now() - startTime) / 60000) + ' minutes',
-      blocksBehind: minTransferLastBlock.length
-        ? curBlockNumber - (minTransferLastBlock[0].minLastBlock ?? 0)
-        : curBlockNumber,
+      blocksBehind,
+      blockWithinRange: blocksBehind < maxBlocksBehind,
     })
   })
 }

--- a/src/status.ts
+++ b/src/status.ts
@@ -1,0 +1,26 @@
+import { database } from './database/db'
+import { LAST_BLOCKS_TABLE_NAME } from './indexer/blocks'
+import { VERSION } from './config'
+import { Event } from './indexer'
+import { getContractKit } from './util/utils'
+import { Request, Response } from 'express'
+
+export function getStatusHandler(startTime: number) {
+  return async (_req: Request, res: Response) => {
+    const kit = await getContractKit()
+    const curBlockNumber = await kit.web3.eth.getBlockNumber()
+    const minTransferLastBlock = await database(LAST_BLOCKS_TABLE_NAME)
+      .min('lastBlock as minLastBlock')
+      .where('key', 'like', `%_${Event.Transfer}`)
+
+    res.status(200).json({
+      version: VERSION,
+      serviceStartTime: new Date(startTime).toUTCString(),
+      serviceRunDuration:
+        Math.floor((Date.now() - startTime) / 60000) + ' minutes',
+      blocksBehind: minTransferLastBlock.length
+        ? curBlockNumber - (minTransferLastBlock[0].minLastBlock ?? 0)
+        : curBlockNumber,
+    })
+  }
+}

--- a/src/status.ts
+++ b/src/status.ts
@@ -4,9 +4,10 @@ import { VERSION } from './config'
 import { Event } from './indexer'
 import { getContractKit } from './util/utils'
 import { Request, Response } from 'express'
+import { asyncRoute } from './util/async-route'
 
 export function getStatusHandler(startTime: number) {
-  return async (_req: Request, res: Response) => {
+  return asyncRoute(async (_req: Request, res: Response) => {
     const kit = await getContractKit()
     const curBlockNumber = await kit.web3.eth.getBlockNumber()
     const minTransferLastBlock = await database(LAST_BLOCKS_TABLE_NAME)
@@ -22,5 +23,5 @@ export function getStatusHandler(startTime: number) {
         ? curBlockNumber - (minTransferLastBlock[0].minLastBlock ?? 0)
         : curBlockNumber,
     })
-  }
+  })
 }

--- a/src/util/async-route.ts
+++ b/src/util/async-route.ts
@@ -6,6 +6,7 @@ export function asyncRoute(handler: express.Handler) {
     res: express.Response,
     next: express.NextFunction,
   ) => {
-    Promise.resolve(handler(req, res, next)).catch(next)
+    // returns to make testing more straightforward. the output is not actually needed.
+    return Promise.resolve(handler(req, res, next)).catch(next)
   }
 }

--- a/src/util/async-route.ts
+++ b/src/util/async-route.ts
@@ -1,0 +1,11 @@
+import express from 'express'
+
+export function asyncRoute(handler: express.Handler) {
+  return (
+    req: express.Request,
+    res: express.Response,
+    next: express.NextFunction,
+  ) => {
+    Promise.resolve(handler(req, res, next)).catch(next)
+  }
+}

--- a/test/async-route.test.ts
+++ b/test/async-route.test.ts
@@ -1,0 +1,19 @@
+import { asyncRoute } from '../src/util/async-route'
+import { Request, Response } from 'express'
+
+describe('async-route', () => {
+  it('calls next with error if handler throws', async () => {
+    const handler = jest.fn().mockRejectedValue(new Error('test'))
+    const route = asyncRoute(handler)
+    const next = jest.fn()
+    await route({} as Request, {} as Response, next)
+    expect(next).toHaveBeenCalled()
+  })
+  it('avoids calling next if handler does not throw', async () => {
+    const handler = jest.fn().mockResolvedValue(undefined)
+    const route = asyncRoute(handler)
+    const next = jest.fn()
+    await route({} as Request, {} as Response, next)
+    expect(next).not.toHaveBeenCalled()
+  })
+})

--- a/test/status.test.ts
+++ b/test/status.test.ts
@@ -2,7 +2,7 @@ import { ContractKit } from '@celo/contractkit'
 import { database, initDatabase } from '../src/database/db'
 import { mocked } from 'ts-jest/utils'
 import { getContractKit } from '../src/util/utils'
-import { getStatusHandler } from '../src/status'
+import { DEFAULT_MAX_BLOCKS_BEHIND, getStatusHandler } from '../src/status'
 import { Request, Response } from 'express'
 
 jest.mock('../src/util/utils')
@@ -10,7 +10,7 @@ jest.mock('../src/config', () => ({
   VERSION: 'fake-version',
 }))
 
-describe('status', () => {
+describe('getStatusHandler', () => {
   const mockGetBlockNumber = jest.fn()
   const mockContractKit = {
     web3: {
@@ -19,13 +19,14 @@ describe('status', () => {
       },
     },
   } as unknown as ContractKit
+  const minBlock = 5
   beforeEach(async () => {
     await initDatabase()
     await database.table('last_blocks').truncate()
     await database('last_blocks').insert([
       {
         key: 'testToken1_Transfer',
-        lastBlock: 5,
+        lastBlock: minBlock,
       },
       {
         key: 'testToken2_Transfer',
@@ -38,25 +39,86 @@ describe('status', () => {
   afterEach(() => {
     return database.destroy()
   })
-  it('getStatusHandler', async () => {
-    const mockResponse = {
-      status: jest.fn().mockReturnThis(),
-      json: jest.fn(),
-    }
-    mockGetBlockNumber.mockResolvedValue(17)
-    const mockStartTime = 1689116816000 // epoch millis for july 11, 2023
-    Date.now = jest.fn().mockReturnValue(mockStartTime + 150000) // 2.5 minutes past start time
-    await getStatusHandler(mockStartTime)(
-      {} as unknown as Request,
-      mockResponse as unknown as Response,
-      jest.fn(),
-    )
-    expect(mockResponse.status).toBeCalledWith(200)
-    expect(mockResponse.json).toBeCalledWith({
-      version: 'fake-version',
-      serviceStartTime: 'Tue, 11 Jul 2023 23:06:56 GMT',
-      serviceRunDuration: '2 minutes',
-      blocksBehind: 12,
+  const mockResponse = {
+    status: jest.fn().mockReturnThis(),
+    json: jest.fn(),
+  }
+  const mockStartTime = 1689116816000 // epoch millis for july 11, 2023
+  Date.now = jest.fn().mockReturnValue(mockStartTime + 150000) // 2.5 minutes past start time
+  const mockNext = jest.fn()
+  const statusHandler = getStatusHandler(mockStartTime)
+  describe('without query parameters', () => {
+    it('works when within range', async () => {
+      mockGetBlockNumber.mockReturnValue(
+        DEFAULT_MAX_BLOCKS_BEHIND + minBlock - 1,
+      )
+      await statusHandler(
+        {} as unknown as Request,
+        mockResponse as unknown as Response,
+        mockNext,
+      )
+      expect(mockNext).not.toHaveBeenCalled()
+      expect(mockResponse.status).toBeCalledWith(200)
+      expect(mockResponse.json).toBeCalledWith({
+        version: 'fake-version',
+        serviceStartTime: 'Tue, 11 Jul 2023 23:06:56 GMT',
+        serviceRunDuration: '2 minutes',
+        blocksBehind: DEFAULT_MAX_BLOCKS_BEHIND - 1,
+        blockWithinRange: true,
+      })
+    })
+    it('works when too far behind', async () => {
+      mockGetBlockNumber.mockReturnValue(DEFAULT_MAX_BLOCKS_BEHIND + minBlock)
+      await statusHandler(
+        {} as unknown as Request,
+        mockResponse as unknown as Response,
+        mockNext,
+      )
+      expect(mockNext).not.toHaveBeenCalled()
+      expect(mockResponse.status).toBeCalledWith(200)
+      expect(mockResponse.json).toBeCalledWith({
+        version: 'fake-version',
+        serviceStartTime: 'Tue, 11 Jul 2023 23:06:56 GMT',
+        serviceRunDuration: '2 minutes',
+        blocksBehind: DEFAULT_MAX_BLOCKS_BEHIND,
+        blockWithinRange: false,
+      })
+    })
+  })
+  describe('using query parameters', () => {
+    it('works when within range', async () => {
+      mockGetBlockNumber.mockReturnValue(99 + minBlock)
+      await statusHandler(
+        { query: { max_blocks_behind: 100 } } as unknown as Request,
+        mockResponse as unknown as Response,
+        mockNext,
+      )
+      expect(mockNext).not.toHaveBeenCalled()
+      expect(mockResponse.status).toBeCalledWith(200)
+      expect(mockResponse.json).toBeCalledWith({
+        version: 'fake-version',
+        serviceStartTime: 'Tue, 11 Jul 2023 23:06:56 GMT',
+        serviceRunDuration: '2 minutes',
+        blocksBehind: 99,
+        blockWithinRange: true,
+      })
+    })
+    it('works when too far behind', async () => {
+      mockGetBlockNumber.mockReturnValue(100 + minBlock)
+      await statusHandler(
+        { query: { max_blocks_behind: 100 } } as unknown as Request,
+        mockResponse as unknown as Response,
+        mockNext,
+      )
+      expect(mockNext).not.toHaveBeenCalled()
+      expect(mockResponse.status).toBeCalledWith(200)
+      expect(mockResponse.json).toBeCalledWith({
+        version: 'fake-version',
+        serviceStartTime: 'Tue, 11 Jul 2023 23:06:56 GMT',
+        serviceRunDuration: '2 minutes',
+        blocksBehind: 100,
+        blockWithinRange: false,
+      })
     })
   })
 })

--- a/test/status.test.ts
+++ b/test/status.test.ts
@@ -49,6 +49,7 @@ describe('status', () => {
     await getStatusHandler(mockStartTime)(
       {} as unknown as Request,
       mockResponse as unknown as Response,
+      jest.fn(),
     )
     expect(mockResponse.status).toBeCalledWith(200)
     expect(mockResponse.json).toBeCalledWith({

--- a/test/status.test.ts
+++ b/test/status.test.ts
@@ -1,0 +1,61 @@
+import { ContractKit } from '@celo/contractkit'
+import { database, initDatabase } from '../src/database/db'
+import { mocked } from 'ts-jest/utils'
+import { getContractKit } from '../src/util/utils'
+import { getStatusHandler } from '../src/status'
+import { Request, Response } from 'express'
+
+jest.mock('../src/util/utils')
+jest.mock('../src/config', () => ({
+  VERSION: 'fake-version',
+}))
+
+describe('status', () => {
+  const mockGetBlockNumber = jest.fn()
+  const mockContractKit = {
+    web3: {
+      eth: {
+        getBlockNumber: mockGetBlockNumber,
+      },
+    },
+  } as unknown as ContractKit
+  beforeEach(async () => {
+    await initDatabase()
+    await database.table('last_blocks').truncate()
+    await database('last_blocks').insert([
+      {
+        key: 'testToken1_Transfer',
+        lastBlock: 5,
+      },
+      {
+        key: 'testToken2_Transfer',
+        lastBlock: 10,
+      },
+    ])
+    jest.clearAllMocks()
+    mocked(getContractKit).mockResolvedValue(mockContractKit)
+  })
+  afterEach(() => {
+    return database.destroy()
+  })
+  it('getStatusHandler', async () => {
+    const mockResponse = {
+      status: jest.fn().mockReturnThis(),
+      json: jest.fn(),
+    }
+    mockGetBlockNumber.mockResolvedValue(17)
+    const mockStartTime = 1689116816000 // epoch millis for july 11, 2023
+    Date.now = jest.fn().mockReturnValue(mockStartTime + 150000) // 2.5 minutes past start time
+    await getStatusHandler(mockStartTime)(
+      {} as unknown as Request,
+      mockResponse as unknown as Response,
+    )
+    expect(mockResponse.status).toBeCalledWith(200)
+    expect(mockResponse.json).toBeCalledWith({
+      version: 'fake-version',
+      serviceStartTime: 'Tue, 11 Jul 2023 23:06:56 GMT',
+      serviceRunDuration: '2 minutes',
+      blocksBehind: 12,
+    })
+  })
+})


### PR DESCRIPTION
once this is in place, we can set up an uptime check that will alert us when the indexer has stalled out, making it safer to try using forno again and reducing our QuickNode footprint