### PR TITLE
fix(status): exclude escrow transfers

### DIFF
--- a/src/status.ts
+++ b/src/status.ts
@@ -1,7 +1,7 @@
 import { database } from './database/db'
 import { LAST_BLOCKS_TABLE_NAME } from './indexer/blocks'
 import { VERSION } from './config'
-import { Event } from './indexer'
+import { Contract, Event } from './indexer'
 import { getContractKit } from './util/utils'
 import { Request, Response } from 'express'
 import { asyncRoute } from './util/async-route'
@@ -20,6 +20,7 @@ export function getStatusHandler(startTime: number) {
     const minTransferLastBlock = await database(LAST_BLOCKS_TABLE_NAME)
       .min('lastBlock as minLastBlock')
       .where('key', 'like', `%_${Event.Transfer}`)
+      .andWhereNot('key', `${Contract.Escrow}_${Event.Transfer}`)
 
     const blocksBehind = minTransferLastBlock.length
       ? curBlockNumber - (minTransferLastBlock[0].minLastBlock ?? 0)

--- a/test/status.test.ts
+++ b/test/status.test.ts
@@ -32,6 +32,10 @@ describe('getStatusHandler', () => {
         key: 'testToken2_Transfer',
         lastBlock: 10,
       },
+      {
+        key: 'Escrow_Transfer',
+        lastBlock: 1, // this is behind, but should be excluded
+      },
     ])
     jest.clearAllMocks()
     mocked(getContractKit).mockResolvedValue(mockContractKit)


### PR DESCRIPTION
Escrow events haven't been indexed in a while. Excluding them from status checks, we don't use the escrow data anymore